### PR TITLE
Restore support for XML strings in create_survey_element_from_xml

### DIFF
--- a/pyxform/xform2json.py
+++ b/pyxform/xform2json.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import os
+import io
 import re
 import json
 import copy
@@ -171,7 +172,10 @@ def ConvertXmlToDict(root, dictclass=XmlDictObject):
 
 
 def create_survey_element_from_xml(xml_file):
-    sb = XFormToDictBuilder(xml_file)
+    if isinstance(xml_file, basestring):
+        # xml_file may be a string of markup instead of a file-like object
+        xml_file = io.BytesIO(xml_file)
+    sb = XFormToDictBuilder(filelike_obj=xml_file)
     return sb.survey()
 
 


### PR DESCRIPTION
Type sniffing was done by the XFormToDict constructor prior to https://github.com/kobotoolbox/pyxform/commit/69cf43ca5ad6c121f93f043d93825b2780cfc815#diff-ff569158148b00cefcb28fc5913823d4L166