### PR TITLE
Fix spss label syntax file generation

### DIFF
--- a/pyxform/spss/__init__.py
+++ b/pyxform/spss/__init__.py
@@ -20,9 +20,7 @@ from .main import from_dicts
 from .spss import survey_to_spss_label_syntaxes
 from .spss import survey_to_spss_label_zip
 from .utilities import get_spss_variable_name
-from .utilities import get_spss_variable_label
-from .utilities import get_spss_value_label
-
+from .utilities import get_spss_label
 
 __version__= '0.2'
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     version='0.9.22',
     author='modilabs',
     author_email='info@modilabs.org',
-    packages=['pyxform', 'pyxform.odk_validate'],
+    packages=['pyxform', 'pyxform.odk_validate', 'pyxform.spss', 'pyxform.utilities'],
     package_dir={'pyxform': 'pyxform'},
     package_data={
         'pyxform': [


### PR DESCRIPTION
Incorporate the encountered 250 byte/character per line limit for SPSS syntax files.
